### PR TITLE
fix spec_dir in rest_spec indirector

### DIFF
--- a/lib/puppet/indirector/report/rest_spec.rb
+++ b/lib/puppet/indirector/report/rest_spec.rb
@@ -31,7 +31,7 @@ class Puppet::Transaction::Report::RestSpec < Puppet::Transaction::Report::Rest
     # Generate serverspec files
     # TODO: Check that we get the catalog from cache
     resources = Puppet::Resource::Catalog.indirection.find(request.instance.host).resources
-    spec_dir = File.join(Puppet[:vardir], 'policy', 'server')
+    spec_dir = File.join(Puppet[:libdir], 'policy', 'server')
     Puppetx::Policy::AutoSpec.gen_auto_spec_files(resources, spec_dir)
     Puppet.debug('Generated auto_spec files')
 


### PR DESCRIPTION
Pluginsync uses /var/lib/puppet/lib/ directory for syncing plugins in modules, but puppet-policy is looking for specs in /var/lib/puppet/policy/server (I don't have /var/lib/puppet/policy directory by default).

'lib/' was added in spec_dir to fix that problem.