### PR TITLE
enable sync for pre-generated serverspecs

### DIFF
--- a/lib/puppetx/policy/spec.rb
+++ b/lib/puppetx/policy/spec.rb
@@ -1,0 +1,19 @@
+require 'fileutils'
+
+module Puppetx::Policy::Spec
+  def self.copy_spec_files(classes, spec_dir)
+    classes.each do |klass|
+      module_name = klass.split('::').first
+      subclass = klass.split('::')[1..-1].join('/')
+      Puppet[:modulepath].split(':').each do |path|
+        src_spec_dir = path + '/' + module_name + '/files/serverspec/' + subclass
+        if File.directory? src_spec_dir
+          Dir[src_spec_dir + '/*'].each do |filepath|
+            filename = filepath.split('/').last
+            FileUtils.cp(filepath, spec_dir+'/'+klass.gsub('::','_')+'_'+filename)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Here the idea:
1. I'm collecting resources with type 'Class'
2. Getting module name $module from class name
3. Getting tail of class name - $subclass
4. Copying serverspecs from $module/files/serverspec/$subclass directory to /var/lib/puppet/policy/server/.

I have 2 problems: resources with type Class contain stages and "Settings" builtin class. Maybe I can filter this with puppet API. Haven't find methods for this and wrote ugly workaround.
I want to have default serverspecs for module in $module/files/serverspec/, but If parent class doesn't have implementation (or wasn't include to node), I haven't. Maybe I'll write check for directory $module/files/serverspec/policy. It should work

BTW, can you review my commit and say good it or bad?
