### PR TITLE
enable gem and pip providers for package auto_spec

### DIFF
--- a/lib/puppetx/policy/auto_spec/package.rb
+++ b/lib/puppetx/policy/auto_spec/package.rb
@@ -1,9 +1,6 @@
 Puppetx::Policy::AutoSpec.newspec 'Package' do |p|
-  provider = ""
   providers = ['gem', 'pip']
   should = (p[:ensure] == 'absent' or p[:ensure] == 'purged') ? 'should_not' : 'should'
-  if providers.include? p[:provider]
-    provider = ".by('#{p[:provider]}')"
-  end
+  provider = providers.include? p[:provider] ? ".by('#{p[:provider]}')" : ''
   "  describe package('#{p[:name]}') do\n    it { #{should} be_installed#{provider} }\n  end\n"
 end

--- a/lib/puppetx/policy/auto_spec/package.rb
+++ b/lib/puppetx/policy/auto_spec/package.rb
@@ -1,4 +1,9 @@
 Puppetx::Policy::AutoSpec.newspec 'Package' do |p|
+  provider = ""
+  providers = ['gem', 'pip']
   should = (p[:ensure] == 'absent' or p[:ensure] == 'purged') ? 'should_not' : 'should'
-  "  describe package('#{p[:name]}') do\n    it { #{should} be_installed }\n  end\n"
+  if providers.include? p[:provider]
+    provider = ".by('#{p[:provider]}')"
+  end
+  "  describe package('#{p[:name]}') do\n    it { #{should} be_installed#{provider} }\n  end\n"
 end


### PR DESCRIPTION
auto_spec for packages doesn't work if package have different provider like gem or pip. Serverspec can check gem, npm, pecl, pear, pip and cpan but default puppet package provider can only gem and pip from this list.